### PR TITLE
Release/1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+= 1.7.1 - 31.12.2023 =
+
+Fixed:
+* Fatal error on plugin uninstall
+* Do not bulk offload SVG images
+* Compatibility with Gutenberg Interactivity API
+* Type error when fetching image hashes
+
 = 1.7.0 - 03.12.2023 =
 
 Added:

--- a/README.txt
+++ b/README.txt
@@ -100,7 +100,7 @@ If something is still not working for you, please let me know by creating a supp
 
 Fixed:
 * Compatibility with Gutenberg Interactivity API
-
+* Type error when fetching image hashes
 
 = 1.7.0 - 03.12.2023 =
 

--- a/README.txt
+++ b/README.txt
@@ -99,6 +99,7 @@ If something is still not working for you, please let me know by creating a supp
 = 1.7.1 =
 
 Fixed:
+* Do not bulk offload SVG images
 * Compatibility with Gutenberg Interactivity API
 * Type error when fetching image hashes
 

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Donate link: https://www.paypal.com/donate/?business=JRR6QPRGTZ46N&no_recurring=
 Requires at least: 5.6
 Requires PHP: 7.0
 Tested up to: 6.4
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -95,6 +95,8 @@ If something is still not working for you, please let me know by creating a supp
 3. Quick and easy setup wizard
 
 == Changelog ==
+
+= 1.7.1 =
 
 = 1.7.0 - 03.12.2023 =
 

--- a/README.txt
+++ b/README.txt
@@ -98,6 +98,10 @@ If something is still not working for you, please let me know by creating a supp
 
 = 1.7.1 =
 
+Fixed:
+* Compatibility with Gutenberg Interactivity API
+
+
 = 1.7.0 - 03.12.2023 =
 
 Added:

--- a/README.txt
+++ b/README.txt
@@ -96,7 +96,7 @@ If something is still not working for you, please let me know by creating a supp
 
 == Changelog ==
 
-= 1.7.1 =
+= 1.7.1 - 31.12.2023 =
 
 Fixed:
 * Fatal error on plugin uninstall

--- a/README.txt
+++ b/README.txt
@@ -99,6 +99,7 @@ If something is still not working for you, please let me know by creating a supp
 = 1.7.1 =
 
 Fixed:
+* Fatal error on plugin uninstall
 * Do not bulk offload SVG images
 * Compatibility with Gutenberg Interactivity API
 * Type error when fetching image hashes

--- a/app/class-media.php
+++ b/app/class-media.php
@@ -395,7 +395,9 @@ class Media {
 			return $metadata;
 		}
 
-		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+		$mime = get_post_mime_type( $attachment_id );
+
+		if ( ! wp_attachment_is_image( $attachment_id ) || false !== strpos( $mime, 'image/svg' ) ) {
 			update_post_meta( $attachment_id, '_cloudflare_image_skip', true );
 			do_action( 'cf_images_error', 415, __( 'Unsupported media type', 'cf-images' ) );
 			return $metadata;

--- a/app/modules/class-cloudflare-images.php
+++ b/app/modules/class-cloudflare-images.php
@@ -145,7 +145,7 @@ class Cloudflare_Images extends Module {
 			return $image;
 		}
 
-		list( $hash, $cloudflare_image_id ) = self::get_hash_id_url_string( $attachment_id );
+		list( $hash, $cloudflare_image_id ) = self::get_hash_id_url_string( (int) $attachment_id );
 
 		if ( empty( $cloudflare_image_id ) || ( empty( $hash ) && ! $this->is_module_enabled( false, 'custom-path' ) ) ) {
 			do_action( 'cf_images_log', 'Missing Cloudflare Image ID or hash. Attachment ID: %s. Image: %s', $attachment_id, $image );

--- a/app/modules/class-cloudflare-images.php
+++ b/app/modules/class-cloudflare-images.php
@@ -342,6 +342,11 @@ class Cloudflare_Images extends Module {
 			return $filtered_image;
 		}
 
+		// Gutenberg's interactivity module stores image data inside `data-wp-bing--src` attribute, which is caught by our regex.
+		if ( ! filter_var( $src[1], FILTER_VALIDATE_URL ) ) {
+			return $filtered_image;
+		}
+
 		// Find `width` attributes in an image.
 		preg_match( '/width=[\'"]([^\'"]+)/i', $filtered_image, $size );
 

--- a/cf-images.php
+++ b/cf-images.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Offload Media to Cloudflare Images
  * Plugin URI:        https://vcore.au
  * Description:       Offload media library images to the `Cloudflare Images` service.
- * Version:           1.7.1-beta.1
+ * Version:           1.7.1
  * Author:            Anton Vanyukov
  * Author URI:        https://vcore.au
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CF_IMAGES_VERSION', '1.7.1-beta.1' );
+define( 'CF_IMAGES_VERSION', '1.7.1' );
 define( 'CF_IMAGES_DIR_URL', plugin_dir_url( __FILE__ ) );
 
 require_once 'app/class-activator.php';

--- a/cf-images.php
+++ b/cf-images.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Offload Media to Cloudflare Images
  * Plugin URI:        https://vcore.au
  * Description:       Offload media library images to the `Cloudflare Images` service.
- * Version:           1.7.0
+ * Version:           1.7.1-beta.1
  * Author:            Anton Vanyukov
  * Author URI:        https://vcore.au
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CF_IMAGES_VERSION', '1.7.0' );
+define( 'CF_IMAGES_VERSION', '1.7.1-beta.1' );
 define( 'CF_IMAGES_DIR_URL', plugin_dir_url( __FILE__ ) );
 
 require_once 'app/class-activator.php';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cf-images",
   "description": "Offload, Store, Resize & Optimize with Cloudflare Images",
-  "version": "1.7.1-beta.1",
+  "version": "1.7.1",
   "main": "cf-images.php",
   "author": "Anton Vanyukov",
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   ],
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.23.4",
-    "@babel/preset-env": "^7.23.3",
+    "@babel/preset-env": "^7.23.5",
     "@babel/preset-typescript": "^7.23.3",
     "@types/jquery": "^3.5.29",
-    "@types/react": "^18.2.38",
+    "@types/react": "^18.2.41",
     "@types/react-dom": "^18.2.17",
-    "@wordpress/babel-plugin-import-jsx-pragma": "^4.29.0",
-    "@wordpress/eslint-plugin": "^17.3.0",
-    "@wordpress/i18n": "^4.46.0",
-    "@wordpress/prettier-config": "^3.3.0",
+    "@wordpress/babel-plugin-import-jsx-pragma": "^4.30.0",
+    "@wordpress/eslint-plugin": "^17.4.0",
+    "@wordpress/i18n": "^4.47.0",
+    "@wordpress/prettier-config": "^3.4.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
     "mini-css-extract-plugin": "^2.7.6",
@@ -45,7 +45,7 @@
     "classnames": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.20.1"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cf-images",
   "description": "Offload, Store, Resize & Optimize with Cloudflare Images",
-  "version": "1.7.0",
+  "version": "1.7.1-beta.1",
   "main": "cf-images.php",
   "author": "Anton Vanyukov",
   "license": "GPL-2.0-or-later",

--- a/uninstall.php
+++ b/uninstall.php
@@ -66,5 +66,6 @@ $settings = new CF_Images\App\Settings();
 $settings->write_config( 'CF_IMAGES_ACCOUNT_ID' );
 $settings->write_config( 'CF_IMAGES_KEY_TOKEN' );
 
+require_once __DIR__ . '/app/modules/class-module.php';
 require_once __DIR__ . '/app/modules/class-cdn.php';
 CF_Images\App\Modules\CDN::remove_cron();


### PR DESCRIPTION
Fixed:
* Fatal error on plugin uninstall
* Do not bulk offload SVG images
* Compatibility with Gutenberg Interactivity API
* Type error when fetching image hashes