### PR TITLE
Release/1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 Added:
 * Integration with Smart Slider 3
 * Integration with All in One SEO: allow controlling application/ld+json schema image URLs
+* Integration with Rank Math: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
 * Background image support in Spectra plugin when styles are inlined (props @josephdsouza86)
 
 Changed:
 * Improve performance processing external images
+* Rename 'cf_images_can_run' filter to 'cf_images_skip_image' so it's more clear what it does
 
 Fixed:
 * Images being replaced in RSS feeds, regardless of the settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Added:
 Changed:
 * Improve performance processing external images
 
+Fixed:
+* Images being replaced in RSS feeds, regardless of the settings
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Added:
 * Integration with Smart Slider 3
+* Integration with All in One SEO: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added:
 * Integration with Smart Slider 3
 * Integration with All in One SEO: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
+* Background image support in Spectra plugin when styles are inlined (props @josephdsouza86)
 
 Changed:
 * Improve performance processing external images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Added:
 * Integration with Smart Slider 3
 
+Changed:
+* Improve performance processing external images
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+= 1.9.3 =
+
+Added:
+* Integration with Smart Slider 3
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed:
 
 Fixed:
 * Images being replaced in RSS feeds, regardless of the settings
+* Fatal error when a registered image size does not have height or width defined
 
 = 1.9.2 - 17.07.2024 =
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-= 1.9.3 =
+= 1.9.3 - 07.10.2024 =
 
 Added:
 * Integration with Smart Slider 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Added:
 * Integration with Smart Slider 3
+* Filter cf_images_disable_crop to disable auto cropping for registered crop images
 
 Changed:
 * Improve performance processing external images

--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ If something is still not working for you, please let me know by creating a supp
 Added:
 * Integration with Smart Slider 3
 * Integration with All in One SEO: allow controlling application/ld+json schema image URLs
+* Integration with Rank Math: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
 * Background image support in Spectra plugin when styles are inlined (props @josephdsouza86)
 
 Changed:
 * Improve performance processing external images
+* Rename 'cf_images_can_run' filter to 'cf_images_skip_image' so it's more clear what it does
 
 Fixed:
 * Images being replaced in RSS feeds, regardless of the settings

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Changed:
 
 Fixed:
 * Images being replaced in RSS feeds, regardless of the settings
+* Fatal error when a registered image size does not have height or width defined
 
 = 1.9.2 - 17.07.2024 =
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ If something is still not working for you, please let me know by creating a supp
 Added:
 * Integration with Smart Slider 3
 
+Changed:
+* Improve performance processing external images
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Donate link: https://www.paypal.com/donate/?business=JRR6QPRGTZ46N&no_recurring=
 Requires at least: 5.6
 Requires PHP: 7.0
 Tested up to: 6.6
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If something is still not working for you, please let me know by creating a supp
 
 Added:
 * Integration with Smart Slider 3
+* Filter cf_images_disable_crop to disable auto cropping for registered crop images
 
 Changed:
 * Improve performance processing external images

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Added:
 Changed:
 * Improve performance processing external images
 
+Fixed:
+* Images being replaced in RSS feeds, regardless of the settings
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ If something is still not working for you, please let me know by creating a supp
 
 == Changelog ==
 
+= 1.9.3 =
+
+Added:
+* Integration with Smart Slider 3
+
 = 1.9.2 - 17.07.2024 =
 
 Added:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If something is still not working for you, please let me know by creating a supp
 
 Added:
 * Integration with Smart Slider 3
+* Integration with All in One SEO: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
 
 Changed:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If something is still not working for you, please let me know by creating a supp
 
 == Changelog ==
 
-= 1.9.3 =
+= 1.9.3 - 07.10.2024 =
 
 Added:
 * Integration with Smart Slider 3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: cdn, cloudflare images, image AI, compress, optimize
 Donate link: https://www.paypal.com/donate/?business=JRR6QPRGTZ46N&no_recurring=0&item_name=Help+support+the+development+of+the+Cloudflare+Images+plugin+for+WordPress&currency_code=AUD
 Requires at least: 5.6
 Requires PHP: 7.0
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Added:
 * Integration with Smart Slider 3
 * Integration with All in One SEO: allow controlling application/ld+json schema image URLs
 * Filter cf_images_disable_crop to disable auto cropping for registered crop images
+* Background image support in Spectra plugin when styles are inlined (props @josephdsouza86)
 
 Changed:
 * Improve performance processing external images

--- a/app/class-admin.php
+++ b/app/class-admin.php
@@ -123,22 +123,24 @@ class Admin {
 			true
 		);
 
+		$i10n = array(
+			'nonce'          => wp_create_nonce( 'cf-images-nonce' ),
+			'dirURL'         => CF_IMAGES_DIR_URL,
+			'settings'       => apply_filters( 'cf_images_settings', get_option( 'cf-images-settings', Settings::get_defaults() ) ),
+			'cfStatus'       => $this->is_set_up(),
+			'domain'         => get_option( 'cf-images-custom-domain', '' ),
+			'hideSidebar'    => get_site_option( 'cf-images-hide-sidebar' ),
+			'fuzion'         => $this->is_fuzion_api_connected(),
+			'stats'          => $this->get_stats(),
+			'cdnEnabled'     => (bool) get_option( 'cf-images-cdn-enabled', false ),
+			'isNetworkAdmin' => is_multisite() && is_main_site(),
+			'browserTTL'     => get_site_option( 'cf-images-browser-ttl', 172800 ),
+		);
+
 		wp_localize_script(
 			$this->get_slug(),
 			'CFImages',
-			array(
-				'nonce'          => wp_create_nonce( 'cf-images-nonce' ),
-				'dirURL'         => CF_IMAGES_DIR_URL,
-				'settings'       => apply_filters( 'cf_images_settings', get_option( 'cf-images-settings', Settings::get_defaults() ) ),
-				'cfStatus'       => $this->is_set_up(),
-				'domain'         => get_option( 'cf-images-custom-domain', '' ),
-				'hideSidebar'    => get_site_option( 'cf-images-hide-sidebar' ),
-				'fuzion'         => $this->is_fuzion_api_connected(),
-				'stats'          => $this->get_stats(),
-				'cdnEnabled'     => (bool) get_option( 'cf-images-cdn-enabled', false ),
-				'isNetworkAdmin' => is_multisite() && is_main_site(),
-				'browserTTL'     => get_site_option( 'cf-images-browser-ttl', 172800 ),
-			)
+			apply_filters( 'cf_images_i10n', $i10n )
 		);
 	}
 

--- a/app/class-core.php
+++ b/app/class-core.php
@@ -180,6 +180,7 @@ class Core {
 	 * @see Integrations\Shortpixel
 	 * @see Integrations\JS_Composer
 	 * @see Integrations\Flatsome
+	 * @see Integrations\AIO_SEO
 	 */
 	private function init_integrations() {
 		$loader = Loader::get_instance();
@@ -193,6 +194,7 @@ class Core {
 		$loader->integration( 'elementor' );
 		$loader->integration( 'js-composer' );
 		$loader->integration( 'flatsome' );
+		$loader->integration( 'aio-seo' );
 	}
 
 	/**

--- a/app/class-image.php
+++ b/app/class-image.php
@@ -210,7 +210,13 @@ class Image {
 	 * @param bool   $is_src  Is this the src attribute.
 	 */
 	private function process( string $content, bool $is_src = false ) {
-		preg_match_all( '/https?[^\s\'"]*/i', $content, $urls );
+		/**
+		 * Match URLs that start with:
+		 * - http:
+		 * - https:
+		 * - // (but only if this string is at the beginning of a word or after whitespace)
+		 */
+		preg_match_all( '/https?:\S+|(?<!\S)\/\/\S+/i', $content, $urls );
 		if ( ! is_array( $urls ) || empty( $urls[0] ) ) {
 			return;
 		}
@@ -441,6 +447,11 @@ class Image {
 
 		if ( false === $post_id ) {
 			global $wpdb;
+
+			// Normalize the URL.
+			if ( str_starts_with( $url, '//' ) ) {
+				$url = set_url_scheme( $url );
+			}
 
 			$sql = $wpdb->prepare(
 				"SELECT ID FROM $wpdb->posts WHERE guid = %s",

--- a/app/class-image.php
+++ b/app/class-image.php
@@ -358,7 +358,7 @@ class Image {
 			return false;
 		}
 
-		if ( 0 === $this->id ) {
+		if ( 0 === $this->id && $this->is_local_image( $original ) ) {
 			// Could not get image ID from class name, try to get it from URL.
 			$this->id = $this->attachment_url_to_post_id( $original );
 		}
@@ -558,5 +558,32 @@ class Image {
 	 */
 	public function get_id(): int {
 		return $this->id;
+	}
+
+	/**
+	 * Check if this is a local image.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @param string $url Image URL.
+	 *
+	 * @return bool
+	 */
+	private function is_local_image( string $url ): bool {
+		// Normalize the URL.
+		if ( str_starts_with( $url, '//' ) ) {
+			$url = set_url_scheme( $url );
+		}
+
+		$uploads = wp_get_upload_dir();
+
+		// Check if the URL is within the wp-content/uploads directory.
+		$uploads = ! isset( $uploads['baseurl'] ) || false !== strpos( $url, $uploads['baseurl'] );
+
+		if ( false === strpos( $url, content_url() ) && ! $uploads ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/app/class-loader.php
+++ b/app/class-loader.php
@@ -75,6 +75,7 @@ class Loader {
 	 */
 	private function __construct() {
 		require_once __DIR__ . '/modules/class-module.php';
+		require_once __DIR__ . '/integrations/class-integration.php';
 	}
 
 	/**

--- a/app/integrations/class-aio-seo.php
+++ b/app/integrations/class-aio-seo.php
@@ -49,7 +49,7 @@ class AIO_SEO extends Integration {
 		 *
 		 * @see https://github.com/av3nger/cf-images/issues/49
 		 */
-		if ( $this->integration_option_value( true, 'skip_image_object' ) ) {
+		if ( ! $this->integration_option_value( false, 'image_object' ) ) {
 			add_action( 'wp_head', array( $this, 'halt_offload' ), 0 );
 			add_action( 'wp_head', array( $this, 'resume_offload' ), 2 );
 		}
@@ -72,10 +72,10 @@ class AIO_SEO extends Integration {
 
 		return array(
 			array(
-				'name'        => 'skip_image_object',
-				'label'       => esc_html__( 'Ignore ImageObject', 'cf-images' ),
-				'description' => esc_html__( 'Use local image for the ImageObject in the application/ld+json schema.', 'cf-images' ),
-				'value'       => apply_filters( 'cf_images_integration_option_value', true, 'skip_image_object' ),
+				'name'        => 'image_object',
+				'label'       => esc_html__( 'Replace ImageObject', 'cf-images' ),
+				'description' => esc_html__( 'Use Cloudflare image for the ImageObject in the application/ld+json schema.', 'cf-images' ),
+				'value'       => apply_filters( 'cf_images_integration_option_value', false, 'image_object' ),
 			),
 		);
 	}
@@ -86,7 +86,7 @@ class AIO_SEO extends Integration {
 	 * @since 1.9.3
 	 */
 	public function halt_offload() {
-		add_filter( 'cf_images_can_run', '__return_true' );
+		add_filter( 'cf_images_skip_image', '__return_true' );
 	}
 
 	/**
@@ -95,6 +95,6 @@ class AIO_SEO extends Integration {
 	 * @since 1.9.3
 	 */
 	public function resume_offload() {
-		remove_filter( 'cf_images_can_run', '__return_false' );
+		remove_filter( 'cf_images_skip_image', '__return_false' );
 	}
 }

--- a/app/integrations/class-aio-seo.php
+++ b/app/integrations/class-aio-seo.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Integration class for the "All in One SEO" plugin
+ *
+ * This class adds compatibility with the "All in One SEO" plugin.
+ *
+ * @link https://vcore.au
+ *
+ * @package CF_Images
+ * @subpackage CF_Images/App/Integrations
+ * @author Anton Vanyukov <a.vanyukov@vcore.ru>
+ * @since 1.9.3
+ */
+
+namespace CF_Images\App\Integrations;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * AIO_SEO class.
+ *
+ * @since 1.9.3
+ */
+class AIO_SEO extends Integration {
+	/**
+	 * Check if the integration should run.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @return bool
+	 */
+	protected function should_run(): bool {
+		return defined( 'AIOSEO_PLUGIN_NAME' );
+	}
+
+	/**
+	 * Define the variables for the integration.
+	 *
+	 * @since 1.9.3
+	 */
+	protected function init() {
+		$this->name = esc_html__( 'All in One SEO', 'cf-images' );
+		$this->slug = 'aio_seo';
+
+		/**
+		 * Do not replace the ImageObject in application/ld+json schema.
+		 *
+		 * @see https://github.com/av3nger/cf-images/issues/49
+		 */
+		if ( $this->integration_option_value( true, 'skip_image_object' ) ) {
+			add_action( 'wp_head', array( $this, 'halt_offload' ), 0 );
+			add_action( 'wp_head', array( $this, 'resume_offload' ), 2 );
+		}
+	}
+
+	/**
+	 * Define the integration options.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @param array  $options Integration options.
+	 * @param string $slug    Integration slug.
+	 *
+	 * @return array
+	 */
+	public function integration_options( array $options, string $slug ): array {
+		if ( $this->slug !== $slug ) {
+			return $options;
+		}
+
+		return array(
+			array(
+				'name'        => 'skip_image_object',
+				'label'       => esc_html__( 'Ignore ImageObject', 'cf-images' ),
+				'description' => esc_html__( 'Use local image for the ImageObject in the application/ld+json schema.', 'cf-images' ),
+				'value'       => apply_filters( 'cf_images_integration_option_value', true, 'skip_image_object' ),
+			),
+		);
+	}
+
+	/**
+	 * Use a local version of the image in the head section.
+	 *
+	 * @since 1.9.3
+	 */
+	public function halt_offload() {
+		add_filter( 'cf_images_can_run', '__return_true' );
+	}
+
+	/**
+	 * Resume normal operations.
+	 *
+	 * @since 1.9.3
+	 */
+	public function resume_offload() {
+		remove_filter( 'cf_images_can_run', '__return_false' );
+	}
+}

--- a/app/integrations/class-integration.php
+++ b/app/integrations/class-integration.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Base integration functionality
+ *
+ * @link https://vcore.au
+ *
+ * @package CF_Images
+ * @subpackage CF_Images/App/Integrations
+ * @author Anton Vanyukov <a.vanyukov@vcore.ru>
+ * @since 1.9.3
+ */
+
+namespace CF_Images\App\Integrations;
+
+use CF_Images\App\Traits;
+use Exception;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Integration class.
+ *
+ * @since 1.9.3
+ */
+abstract class Integration {
+	use Traits\Ajax;
+
+	/**
+	 * Integration name.
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Integration slug.
+	 *
+	 * @var string
+	 */
+	protected $slug;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since 1.9.3
+	 * @throws Exception If the integration slug is not defined.
+	 */
+	public function __construct() {
+		if ( ! $this->should_run() ) {
+			return;
+		}
+
+		$this->init();
+
+		if ( empty( $this->slug ) || empty( $this->name ) ) {
+			throw new Exception( 'Integration slug or name is not defined.' );
+		}
+
+		add_filter( 'cf_images_i10n', array( $this, 'add_integration' ) );
+		add_filter( 'cf_images_integration_options', array( $this, 'integration_options' ), 10, 2 );
+		add_filter( 'cf_images_integration_option_value', array( $this, 'integration_option_value' ), 10, 2 );
+
+		if ( wp_doing_ajax() ) {
+			add_action( 'wp_ajax_cf_images_update_integrations', array( $this, 'ajax_update_integrations' ) );
+		}
+	}
+
+	/**
+	 * Check if the integration should run.
+	 *
+	 * This will usually be a check if a plugin is active, or a certain class/hook exists.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @return bool
+	 */
+	abstract protected function should_run(): bool;
+
+	/**
+	 * Define the variables for the integration.
+	 *
+	 * @since 1.9.3
+	 */
+	abstract protected function init();
+
+	/**
+	 * Define the integration options.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @param array  $options Integration options.
+	 * @param string $slug    Integration slug.
+	 *
+	 * @return array
+	 */
+	abstract public function integration_options( array $options, string $slug ): array;
+
+	/**
+	 * Add the integration data to the plugin's i10n array.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @param array $i10n Current i10n array.
+	 *
+	 * @return array
+	 */
+	public function add_integration( array $i10n ): array {
+		$i10n['integrationData'][ $this->slug ] = array(
+			'name'    => $this->name,
+			'options' => apply_filters( 'cf_images_integration_options', array(), $this->slug ),
+		);
+
+		return $i10n;
+	}
+
+	/**
+	 * Get the value for the integration option.
+	 *
+	 * @since 1.9.3
+	 *
+	 * @param bool   $fallback    Fallback value.
+	 * @param string $option_name Option name.
+	 *
+	 * @return bool
+	 */
+	public function integration_option_value( bool $fallback, string $option_name ): bool {
+		$options = get_option( 'cf-images-integrations', array() );
+
+		return $options[ $this->slug ][ $option_name ] ?? $fallback;
+	}
+
+	/**
+	 * Update integrations settings.
+	 *
+	 * @since 1.9.3
+	 */
+	public function ajax_update_integrations() {
+		$this->check_ajax_request();
+
+		$data     = filter_input( INPUT_POST, 'data', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+		$settings = get_option( 'cf-images-integrations', array() );
+
+		foreach ( $data as $slug => $options ) {
+			$integration = apply_filters( 'cf_images_integration_options', array(), $slug );
+			if ( empty( $integration ) || empty( $options['options'] ) ) {
+				continue;
+			}
+
+			foreach ( $options['options'] as $option ) {
+				if ( empty( $option['name'] ) || ! isset( $option['value'] ) ) {
+					continue;
+				}
+
+				$settings[ $slug ][ $option['name'] ] = filter_var( $option['value'], FILTER_VALIDATE_BOOLEAN );
+			}
+		}
+
+		update_option( 'cf-images-integrations', $settings, false );
+		wp_send_json_success();
+	}
+}

--- a/app/integrations/class-spectra.php
+++ b/app/integrations/class-spectra.php
@@ -31,6 +31,7 @@ class Spectra {
 	 */
 	public function __construct() {
 		add_filter( 'cf_images_content_attachment_id', array( $this, 'detect_image_id' ), 10, 2 );
+		add_filter( 'uagb_block_attributes_for_css_and_js', array( $this, 'replace_background_images' ) );
 	}
 
 	/**
@@ -57,5 +58,31 @@ class Spectra {
 		}
 
 		return $attachment_id;
+	}
+
+	/**
+	 * Replace background images in Spectra blocks.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return array
+	 */
+	public function replace_background_images( array $attributes ): array {
+		$device_aliases = array( 'Desktop', 'Tablet', 'Mobile' );
+
+		// Check background images for all devices.
+		foreach ( $device_aliases as $device ) {
+			$key = 'backgroundImage' . $device;
+			if ( ! isset( $attributes[ $key ] ) ) {
+				continue;
+			}
+
+			$image = apply_filters( 'wp_get_attachment_image_src', array( $attributes[ $key ]['url'] ), $attributes[ $key ]['id'], '', false );
+
+			// Replace the background image URL.
+			$attributes[ $key ]['url'] = $image[0];
+		}
+
+		return $attributes;
 	}
 }

--- a/app/modules/class-cloudflare-images.php
+++ b/app/modules/class-cloudflare-images.php
@@ -164,7 +164,7 @@ class Cloudflare_Images extends Module {
 		$cf_image = trailingslashit( $this->get_cdn_domain() . "/$hash" ) . $cloudflare_image_id;
 
 		// If this is a known crop image.
-		if ( is_string( $size ) && isset( $this->registered_sizes[ $size ]['crop'] ) && true === $this->registered_sizes[ $size ]['crop'] ) {
+		if ( is_string( $size ) && isset( $this->registered_sizes[ $size ]['crop'] ) && true === $this->registered_sizes[ $size ]['crop'] && ! apply_filters( 'cf_images_disable_crop', false ) ) {
 			$image[0] = $cf_image . '/w=' . $this->registered_sizes[ $size ]['width'] . ',h=' . $this->registered_sizes[ $size ]['height'] . ',fit=crop';
 			return $image;
 		}

--- a/app/modules/class-cloudflare-images.php
+++ b/app/modules/class-cloudflare-images.php
@@ -183,7 +183,7 @@ class Cloudflare_Images extends Module {
 		preg_match( '/-(\d+)x(\d+)\.[a-zA-Z]{3,4}$/', $image[0], $variant_image );
 
 		// Image with `-<width>x<height>` prefix, for example, image-300x125.jpg.
-		if ( isset( $variant_image[1] ) && isset( $variant_image[2] ) ) {
+		if ( isset( $variant_image[1] ) && isset( $variant_image[2] ) && is_array( $this->heights ) && is_array( $this->widths ) ) {
 			// Check if the image is a cropped version.
 			$height_key = array_search( (int) $variant_image[1], $this->heights, true );
 			$width_key  = array_search( (int) $variant_image[2], $this->widths, true );

--- a/app/modules/class-module.php
+++ b/app/modules/class-module.php
@@ -112,7 +112,7 @@ abstract class Module {
 			return false;
 		}
 
-		if ( apply_filters( 'cf_images_can_run', false ) ) {
+		if ( apply_filters( 'cf_images_skip_image', false ) ) {
 			return false;
 		}
 

--- a/app/modules/class-module.php
+++ b/app/modules/class-module.php
@@ -116,7 +116,7 @@ abstract class Module {
 			return false;
 		}
 
-		if ( ! $this->is_module_enabled( false, 'rss-feeds' ) && is_feed() ) {
+		if ( did_action( 'wp' ) && ! $this->is_module_enabled( false, 'rss-feeds' ) && is_feed() ) {
 			return false;
 		}
 

--- a/app/modules/class-module.php
+++ b/app/modules/class-module.php
@@ -116,6 +116,10 @@ abstract class Module {
 			return false;
 		}
 
+		if ( ! $this->is_module_enabled( false, 'rss-feeds' ) && is_feed() ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/assets/_src/app.tsx
+++ b/assets/_src/app.tsx
@@ -11,12 +11,13 @@ import './app.scss';
 import Nav from './components/nav';
 import SettingsProvider from './context/provider';
 import CloudflareSettings from './routes/cloudflare/settings';
-import CloudflareExperimental from './routes/cloudflare/experimental';
+import Experimental from './routes/cloudflare/experimental';
 import Support from './routes/support';
 import ToolsSettings from './routes/tools/settings';
 import Logs from './routes/misc/logs';
 import ImageGenerateRoute from './routes/image/generate';
 import ToolsPremium from './routes/tools/premium';
+import Integrations from './routes/cloudflare/integrations';
 
 /**
  * App
@@ -24,6 +25,25 @@ import ToolsPremium from './routes/tools/premium';
  * @class
  */
 const App = () => {
+	const routes = () => {
+		return (
+			<Routes>
+				<Route index element={<CloudflareSettings />} />
+				<Route path="/cf/integrations" element={<Integrations />} />
+				<Route path="/cf/experimental" element={<Experimental />} />
+				<Route path="/tools/settings" element={<ToolsSettings />} />
+				<Route path="/tools/premium" element={<ToolsPremium />} />
+				<Route
+					path="/image/generate"
+					element={<ImageGenerateRoute />}
+				/>
+				<Route path="/misc/logs" element={<Logs />} />
+				<Route path="/misc/support" element={<Support />} />
+				<Route path="*" element={<Navigate to="/" replace />} />
+			</Routes>
+		);
+	};
+
 	return (
 		<HashRouter>
 			<SettingsProvider>
@@ -32,33 +52,7 @@ const App = () => {
 				</div>
 
 				<div className="column">
-					<div className="box">
-						<Routes>
-							<Route index element={<CloudflareSettings />} />
-							<Route
-								path="/cf/experimental"
-								element={<CloudflareExperimental />}
-							/>
-							<Route
-								path="/tools/settings"
-								element={<ToolsSettings />}
-							/>
-							<Route
-								path="/tools/premium"
-								element={<ToolsPremium />}
-							/>
-							<Route
-								path="/image/generate"
-								element={<ImageGenerateRoute />}
-							/>
-							<Route path="/misc/logs" element={<Logs />} />
-							<Route path="/misc/support" element={<Support />} />
-							<Route
-								path="*"
-								element={<Navigate to="/" replace />}
-							/>
-						</Routes>
-					</div>
+					<div className="box">{routes()}</div>
 				</div>
 			</SettingsProvider>
 		</HashRouter>

--- a/assets/_src/components/card.tsx
+++ b/assets/_src/components/card.tsx
@@ -18,7 +18,7 @@ import SettingsContext from '../context/settings';
 type CardProps = {
 	children: ReactElement;
 	footer?: ReactElement;
-	icon: string;
+	icon?: string;
 	id?: string;
 	title: string;
 	wide?: boolean;
@@ -39,7 +39,7 @@ type CardProps = {
 const Card = ({
 	children,
 	footer,
-	icon,
+	icon = '',
 	id,
 	title,
 	wide = false,
@@ -61,9 +61,11 @@ const Card = ({
 					})}
 				>
 					<div className="media is-align-content-center is-align-items-center">
-						<div className="media-left">
-							<Icon path={icon} size={2} />
-						</div>
+						{icon && (
+							<div className="media-left">
+								<Icon path={icon} size={2} />
+							</div>
+						)}
 						<div className="media-content">
 							<p
 								className={classNames('title is-4', {

--- a/assets/_src/components/nav.tsx
+++ b/assets/_src/components/nav.tsx
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
 import SettingsContext from '../context/settings';
 
 const Nav = () => {
-	const { modules, noticeHidden } = useContext(SettingsContext);
+	const { modules, noticeHidden, integrations } = useContext(SettingsContext);
 
 	const getClass = (status: boolean) => {
 		return status ? 'is-active' : '';
@@ -40,6 +40,16 @@ const Nav = () => {
 						{__('Settings', 'cf-images')}
 					</NavLink>
 				</li>
+				{typeof integrations === 'object' && (
+					<li>
+						<NavLink
+							to="/cf/integrations"
+							className={({ isActive }) => getClass(isActive)}
+						>
+							{__('Integrations', 'cf-images')}
+						</NavLink>
+					</li>
+				)}
 				<li>
 					<NavLink
 						to="/cf/experimental"

--- a/assets/_src/context/provider.tsx
+++ b/assets/_src/context/provider.tsx
@@ -24,10 +24,12 @@ const SettingsProvider = ({ children }: { children: ReactElement[] }) => {
 		hideSidebar,
 		isNetworkAdmin,
 		settings,
+		integrationData,
 	} = window.CFImages;
 
 	const [stats, setStats] = useState(window.CFImages.stats);
 	const [modules, setModules] = useState(settings);
+	const [integrations, setIntegrations] = useState(integrationData);
 	const [noticeHidden, hideNotice] = useState(hideSidebar);
 	const [hasFuzion, setFuzion] = useState(fuzion);
 	const [cfConnected, setCfConnected] = useState(cfStatus);
@@ -45,6 +47,25 @@ const SettingsProvider = ({ children }: { children: ReactElement[] }) => {
 
 		post('cf_images_update_settings', newSettings)
 			.then(() => setModules(newSettings))
+			.catch(window.console.log);
+	};
+
+	const setIntegration = (
+		module: string,
+		setting: string,
+		value: boolean
+	) => {
+		const newIntegrations = { ...integrations };
+
+		// Find the object in the "options" array where "name" = "setting".
+		newIntegrations[module].options.forEach((option: IntegrationOption) => {
+			if (option.name === setting) {
+				option.value = value; // Update the value.
+			}
+		});
+
+		post('cf_images_update_integrations', newIntegrations)
+			.then(() => setIntegrations(newIntegrations))
 			.catch(window.console.log);
 	};
 
@@ -69,6 +90,8 @@ const SettingsProvider = ({ children }: { children: ReactElement[] }) => {
 				setDomain,
 				cdnEnabled,
 				setCdnEnabled,
+				integrations,
+				setIntegration,
 			}}
 		>
 			{children}

--- a/assets/_src/globals.d.ts
+++ b/assets/_src/globals.d.ts
@@ -21,12 +21,15 @@ interface CFImages {
     stats: StatsType;
     cdnEnabled: boolean;
     isNetworkAdmin: boolean;
+    integrationData: object;
 }
 
 interface SettingsContextType {
     browserTTL: string;
     modules: object;
     setModule: (module: string, value: boolean) => void;
+    integrations: object;
+    setIntegration: (module: string, setting: string, value: boolean) => void;
     noticeHidden: boolean;
     hideNotice: (hide: boolean) => void;
     hasFuzion: boolean;
@@ -51,4 +54,11 @@ interface StatsType {
     size_before: number;
     synced: number;
     image_ai: number;
+}
+
+interface IntegrationOption {
+    name: string;
+    label: string;
+    value: boolean;
+    description: string;
 }

--- a/assets/_src/routes/cloudflare/experimental.tsx
+++ b/assets/_src/routes/cloudflare/experimental.tsx
@@ -22,7 +22,7 @@ import CloudflareLogin from './login';
  *
  * @class
  */
-const CloudflareExperimental = () => {
+const Experimental = () => {
 	const { cfConnected } = useContext(SettingsContext);
 
 	if (!cfConnected) {
@@ -54,4 +54,4 @@ const CloudflareExperimental = () => {
 	);
 };
 
-export default CloudflareExperimental;
+export default Experimental;

--- a/assets/_src/routes/cloudflare/integrations.tsx
+++ b/assets/_src/routes/cloudflare/integrations.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { useContext } from 'react';
+import Icon from '@mdi/react';
+import { mdiInformationOutline } from '@mdi/js';
+
+/**
+ * Internal dependencies
+ */
+import SettingsContext from '../../context/settings';
+import CloudflareLogin from './login';
+import Card from '../../components/card';
+
+/**
+ * Cloudflare Images integration settings routes.
+ *
+ * @class
+ */
+const Integrations = () => {
+	const { cfConnected, integrations, setIntegration } =
+		useContext(SettingsContext);
+
+	if (!cfConnected) {
+		return <CloudflareLogin />;
+	}
+
+	const modules = Object.entries(integrations).map(
+		([module, integration]) => {
+			const options = Object.entries(integration.options).map(
+				([, option]: [string, IntegrationOption]) => {
+					return (
+						<div className="field" key={option.name}>
+							<input
+								checked={!!option.value}
+								className="switch is-rtl is-rounded is-small"
+								id={`cf-images-${option.name}`}
+								name={`cf-images-${option.name}`}
+								onChange={(e) =>
+									setIntegration(
+										module,
+										option.name,
+										e.target.checked
+									)
+								}
+								type="checkbox"
+							/>
+							<label htmlFor={`cf-images-${option.name}`}>
+								{option.label}
+								<span
+									className="icon is-small ml-2 has-tooltip-arrow has-tooltip-multiline"
+									data-tooltip={option.description}
+								>
+									<Icon
+										path={mdiInformationOutline}
+										size={1}
+									/>
+								</span>
+							</label>
+						</div>
+					);
+				}
+			);
+
+			return (
+				<Card title={integration.name} key={module}>
+					<div className="content">{options}</div>
+				</Card>
+			);
+		}
+	);
+
+	return <div className="columns is-multiline">{modules}</div>;
+};
+
+export default Integrations;

--- a/cf-images.php
+++ b/cf-images.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Offload Media to Cloudflare Images
  * Plugin URI:        https://vcore.au
  * Description:       Offload media library images to the `Cloudflare Images` service.
- * Version:           1.9.3-beta.1
+ * Version:           1.9.3
  * Author:            Anton Vanyukov
  * Author URI:        https://vcore.au
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CF_IMAGES_VERSION', '1.9.3-beta.1' );
+define( 'CF_IMAGES_VERSION', '1.9.3' );
 define( 'CF_IMAGES_DIR_URL', plugin_dir_url( __FILE__ ) );
 
 require_once 'app/class-activator.php';

--- a/cf-images.php
+++ b/cf-images.php
@@ -14,7 +14,7 @@
  * Plugin Name:       Offload Media to Cloudflare Images
  * Plugin URI:        https://vcore.au
  * Description:       Offload media library images to the `Cloudflare Images` service.
- * Version:           1.9.2
+ * Version:           1.9.3-beta.1
  * Author:            Anton Vanyukov
  * Author URI:        https://vcore.au
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'CF_IMAGES_VERSION', '1.9.2' );
+define( 'CF_IMAGES_VERSION', '1.9.3-beta.1' );
 define( 'CF_IMAGES_DIR_URL', plugin_dir_url( __FILE__ ) );
 
 require_once 'app/class-activator.php';

--- a/package.json
+++ b/package.json
@@ -11,25 +11,25 @@
   ],
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.24.7",
-    "@babel/preset-env": "^7.24.7",
+    "@babel/preset-env": "^7.24.8",
     "@babel/preset-typescript": "^7.24.7",
     "@creativebulma/bulma-tooltip": "^1.2.0",
     "@types/jquery": "^3.5.30",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@wordpress/babel-plugin-import-jsx-pragma": "^5.2.0",
-    "@wordpress/eslint-plugin": "^19.2.0",
-    "@wordpress/i18n": "^5.2.0",
-    "@wordpress/prettier-config": "^4.2.0",
+    "@wordpress/babel-plugin-import-jsx-pragma": "^5.3.0",
+    "@wordpress/eslint-plugin": "^20.0.0",
+    "@wordpress/i18n": "^5.3.0",
+    "@wordpress/prettier-config": "^4.3.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
     "mini-css-extract-plugin": "^2.9.0",
-    "prettier": "^3.3.2",
-    "sass": "^1.77.6",
+    "prettier": "^3.3.3",
+    "sass": "^1.77.8",
     "sass-loader": "^14.2.1",
     "terser-webpack-plugin": "^5.3.10",
     "typescript": "^5.5.3",
-    "webpack": "^5.92.1",
+    "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4"
   },
   "scripts": {
@@ -46,7 +46,7 @@
     "classnames": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.24.0"
+    "react-router-dom": "^6.25.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -10,26 +10,26 @@
     "optimization"
   ],
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "^7.25.2",
-    "@babel/preset-env": "^7.25.3",
-    "@babel/preset-typescript": "^7.24.7",
+    "@babel/plugin-transform-react-jsx": "^7.25.7",
+    "@babel/preset-env": "^7.25.7",
+    "@babel/preset-typescript": "^7.25.7",
     "@creativebulma/bulma-tooltip": "^1.2.0",
-    "@types/jquery": "^3.5.30",
-    "@types/react": "^18.3.4",
+    "@types/jquery": "^3.5.31",
+    "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
-    "@wordpress/babel-plugin-import-jsx-pragma": "^5.5.0",
-    "@wordpress/eslint-plugin": "^20.2.0",
-    "@wordpress/i18n": "^5.5.0",
-    "@wordpress/prettier-config": "^4.5.0",
-    "babel-loader": "^9.1.3",
+    "@wordpress/babel-plugin-import-jsx-pragma": "^5.9.0",
+    "@wordpress/eslint-plugin": "^21.2.0",
+    "@wordpress/i18n": "^5.9.0",
+    "@wordpress/prettier-config": "^4.9.0",
+    "babel-loader": "^9.2.1",
     "css-loader": "^7.1.2",
     "mini-css-extract-plugin": "^2.9.1",
     "prettier": "^3.3.3",
-    "sass": "^1.77.8",
-    "sass-loader": "^16.0.1",
+    "sass": "^1.79.4",
+    "sass-loader": "^16.0.2",
     "terser-webpack-plugin": "^5.3.10",
-    "typescript": "^5.5.4",
-    "webpack": "^5.93.0",
+    "typescript": "^5.6.2",
+    "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4"
   },
   "scripts": {
@@ -46,7 +46,7 @@
     "classnames": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1"
+    "react-router-dom": "^6.26.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cf-images",
   "description": "Offload, Store, Resize & Optimize with Cloudflare Images",
-  "version": "1.9.2",
+  "version": "1.9.3-beta.1",
   "main": "cf-images.php",
   "author": "Anton Vanyukov",
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -10,25 +10,25 @@
     "optimization"
   ],
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "^7.24.7",
-    "@babel/preset-env": "^7.24.8",
+    "@babel/plugin-transform-react-jsx": "^7.25.2",
+    "@babel/preset-env": "^7.25.3",
     "@babel/preset-typescript": "^7.24.7",
     "@creativebulma/bulma-tooltip": "^1.2.0",
     "@types/jquery": "^3.5.30",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
-    "@wordpress/babel-plugin-import-jsx-pragma": "^5.3.0",
-    "@wordpress/eslint-plugin": "^20.0.0",
-    "@wordpress/i18n": "^5.3.0",
-    "@wordpress/prettier-config": "^4.3.0",
+    "@wordpress/babel-plugin-import-jsx-pragma": "^5.5.0",
+    "@wordpress/eslint-plugin": "^20.2.0",
+    "@wordpress/i18n": "^5.5.0",
+    "@wordpress/prettier-config": "^4.5.0",
     "babel-loader": "^9.1.3",
     "css-loader": "^7.1.2",
-    "mini-css-extract-plugin": "^2.9.0",
+    "mini-css-extract-plugin": "^2.9.1",
     "prettier": "^3.3.3",
     "sass": "^1.77.8",
-    "sass-loader": "^14.2.1",
+    "sass-loader": "^16.0.1",
     "terser-webpack-plugin": "^5.3.10",
-    "typescript": "^5.5.3",
+    "typescript": "^5.5.4",
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4"
   },
@@ -46,7 +46,7 @@
     "classnames": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.25.0"
+    "react-router-dom": "^6.26.1"
   },
   "babel": {
     "presets": [

--- a/uninstall.php
+++ b/uninstall.php
@@ -44,6 +44,8 @@ delete_option( 'cf-image-ai-api-key' );
 delete_option( 'cf-images-settings' );
 delete_option( 'cf-images-custom-path' );
 delete_option( 'cf-images-cdn-enabled' );
+delete_option( 'cf-images-integrations' );
+
 
 /**
  * These have been removed since version 1.4.0.


### PR DESCRIPTION
Added:
* Integration with Smart Slider 3
* Integration with All in One SEO: allow controlling application/ld+json schema image URLs
* Integration with Rank Math: allow controlling application/ld+json schema image URLs
* Filter cf_images_disable_crop to disable auto cropping for registered crop images
* Background image support in Spectra plugin when styles are inlined (props @josephdsouza86)

Changed:
* Improve performance processing external images
* Rename **_cf_images_can_run_** filter to **_cf_images_skip_image_** so it's more clear what it does

Fixed:
* Images being replaced in RSS feeds, regardless of the settings
* Fatal error when a registered image size does not have height or width defined